### PR TITLE
Prod Push

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,15 +72,15 @@
   },
   "scripts": {
     "compile": "rm -rf dist/ && tsc",
-    "start": "node --max-old-space-size=8192 dist/src/app",
+    "start": "node --max-old-space-size=4096 dist/src/app",
     "pm2": "pm2 start dist/src/app.js --name 'DEL'",
     "css-compile": "sh ./scripts/css_build.sh",
     "setup": "node scripts/setup",
     "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect",
     "dev": "nodemon --exec \"tsc && fuser -k 3001/tcp && node dist/src/app.js\" --ext ts",
-    "update": "npm run compile && pm2 restart 1",
-    "updatel": "npm run compile && pm2 restart 1 && pm2 logs 1"
+    "update": "npm run compile && pm2 restart DEL",
+    "updatel": "npm run compile && pm2 restart DEL && pm2 logs DEL"
   },
   "repository": {
     "type": "git",

--- a/src/Routes/autosync.ts
+++ b/src/Routes/autosync.ts
@@ -113,7 +113,7 @@ router.get('/bots', async (req, res) => {
 
         if (app.bot_public === false) throw 'Bot is not public'
     } catch (e) {
-        if (!botExists.status.archived) discord.channels.alerts.send(`${settings.emoji.warn} failed to autosync bot **${botExists.name}** \`(${id})\`: ${e}\n<${settings.website.url}/bots/${id}>`)
+        if (!botExists.status.archived) (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync bot **${botExists.name}** \`(${id})\`: ${e}\n<${settings.website.url}/bots/${id}>`)
     }
 
     await global.redis?.hset("autosync", "nextBot", getNext(ids, id))
@@ -159,7 +159,7 @@ router.get('/servers', async (req, res) => {
 
         await serverCache.updateServer(id);
     } catch (e) {
-        discord.channels.alerts.send(`${settings.emoji.warn} failed to autosync server **${server.name}** \`(${id})\`: ${e}\n<${settings.website.url}/servers/${id}>`)
+        (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync server **${server.name}** \`(${id})\`: ${e}\n<${settings.website.url}/servers/${id}>`)
     }
 
     await global.redis?.hset("autosync", "nextServer", getNext(ids, id))
@@ -215,7 +215,7 @@ router.get('/templates', async (req, res) => {
 
         await templateCache.updateTemplate(id);
     } catch (e) {
-        discord.channels.alerts.send(`${settings.emoji.warn} failed to autosync template **${dbTemplate.name}** \`(${id})\`: ${e}\n<${settings.website.url}/templates/${id}>`)
+        (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync template **${dbTemplate.name}** \`(${id})\`: ${e}\n<${settings.website.url}/templates/${id}>`)
     }
 
     await global.redis?.hset("autosync", "nextTemplate", getNext(ids, id))

--- a/src/Routes/autosync.ts
+++ b/src/Routes/autosync.ts
@@ -25,6 +25,8 @@ import * as botCache from "../Util/Services/botCaching.js";
 import * as serverCache from "../Util/Services/serverCaching.js";
 import * as templateCache from "../Util/Services/templateCaching.js";
 import * as userCache from "../Util/Services/userCaching.js";
+import * as functions from "../Util/Function/main.js";
+import { MessageEmbed } from "discord.js";
 import { APIInvite, APITemplate, RESTGetAPIInviteQuery, RESTPostOAuth2AccessTokenResult, APIApplicationCommand, OAuth2Scopes, Routes, APIApplication, APIUser } from "discord-api-types/v10";
 import settings from "../../settings.json" assert { type: "json" };
 
@@ -46,7 +48,7 @@ router.get('/bots', async (req, res) => {
 
     const ids = (await global.redis?.hkeys("bots")).sort()
     if (!ids) return res.sendStatus(503)
-    
+
     if (!id) id = ids[0]
 
     const botExists: delBot = await global.db
@@ -57,7 +59,7 @@ router.get('/bots', async (req, res) => {
         const app = await discord.bot.api.applications(botExists.clientID || id).rpc.get() as APIApplication
 
         let commands: APIApplicationCommand[] = botExists.commands || []
-        
+
         if (botExists.scopes?.slashCommands) {
             const owner = await userCache.getUser(botExists.owner.id)
 
@@ -72,7 +74,7 @@ router.get('/bots', async (req, res) => {
                                         auth: {
                                             accessToken,
                                             refreshToken,
-                                            expires: Date.now() + result.expires_in*1000
+                                            expires: Date.now() + result.expires_in * 1000
                                         }
                                     }
                                 }
@@ -81,8 +83,8 @@ router.get('/bots', async (req, res) => {
                         }
                     })
                 }
-    
-                const receivedCommands = await (await fetch('https://discord.com/api/v8'+Routes.applicationCommands(app.id), {headers: {authorization: `Bearer ${owner.auth.accessToken}`}})).json().catch(() => {}) as APIApplicationCommand[]
+
+                const receivedCommands = await (await fetch('https://discord.com/api/v8' + Routes.applicationCommands(app.id), { headers: { authorization: `Bearer ${owner.auth.accessToken}` } })).json().catch(() => { }) as APIApplicationCommand[]
                 if (Array.isArray(receivedCommands)) commands = receivedCommands;
             }
         }
@@ -90,10 +92,10 @@ router.get('/bots', async (req, res) => {
         let userFlags = 0
 
         if (botExists.scopes?.bot) {
-            const user = await discord.bot.api.users(id).get().catch(() => {}) as APIUser
+            const user = await discord.bot.api.users(id).get().catch(() => { }) as APIUser
             if (user.public_flags) userFlags = user.public_flags
         }
-        
+
         await global.db.collection("bots").updateOne(
             { _id: id },
             {
@@ -126,7 +128,7 @@ router.get('/servers', async (req, res) => {
 
     const ids = (await global.redis?.hkeys("servers")).sort()
     if (!ids) return res.sendStatus(503)
-    
+
     if (!id) id = ids[0]
 
     const server: delServer = await global.db
@@ -134,12 +136,12 @@ router.get('/servers', async (req, res) => {
         .findOne({ _id: id });
 
     if (server) try {
-        const invite = await discord.bot.api.invites(server.inviteCode).get({query: {with_counts: true, with_expiration: true} as RESTGetAPIInviteQuery}) as APIInvite
+        const invite = await discord.bot.api.invites(server.inviteCode).get({ query: { with_counts: true, with_expiration: true } as RESTGetAPIInviteQuery }) as APIInvite
 
         if (invite.guild.id !== server._id) throw 'Invite points to a different server'
 
         if (invite.expires_at) throw 'This invite is set to expire'
-        
+
         await global.db.collection("servers").updateOne(
             { _id: id },
             {
@@ -159,7 +161,46 @@ router.get('/servers', async (req, res) => {
 
         await serverCache.updateServer(id);
     } catch (e) {
-        (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync server **${server.name}** \`(${id})\`: ${e}\n<${settings.website.url}/servers/${id}>`)
+        await global.db.collection("servers").deleteOne({ _id: id });
+        await global.db.collection("audit").insertOne({
+            type: "REMOVE_SERVER",
+            executor: "AutoSync",
+            target: id,
+            date: Date.now(),
+            reason: "Failed to autosync server, assuming the invite is invalid.",
+            reasonType: 0 // again, assuming 0 is the only option here
+        });
+
+        await serverCache.deleteServer(id);
+
+        const embed = new MessageEmbed();
+        embed.setColor(0x2f3136);
+        embed.setTitle("Reason");
+        embed.setDescription(req.body.reason);
+
+        (await discord.channels.logs).send({
+            content: `${settings.emoji.delete} **AutoSync System** removed server **${functions.escapeFormatting(
+                server.name
+            )}** \`(${server._id})\``,
+            embeds: [embed]
+        });
+
+        const owner = await discord.getMember(server.owner.id);
+        if (owner)
+            owner
+                .send(
+                    `${settings.emoji.delete
+                    } **|** Your server **${functions.escapeFormatting(
+                        server.name
+                    )}** \`(${server._id})\` has been removed!\n**Reason:** \`Our AutoSync system has determined this server has either been deleted, or the invite provided to us has expired. If your server is still active, please repost it with a permanent invite!\``
+                )
+                .catch((e: string) => {
+                    console.error(e);
+                });
+
+        await discord.postWebMetric("server");
+        // keeping this here incase the team wants it
+        // (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync server **${server.name}** \`(${id})\`: ${e}\n<${settings.website.url}/servers/${id}>`)
     }
 
     await global.redis?.hset("autosync", "nextServer", getNext(ids, id))
@@ -172,7 +213,7 @@ router.get('/templates', async (req, res) => {
 
     const ids = (await global.redis?.hkeys("templates")).sort()
     if (!ids) return res.sendStatus(503)
-    
+
     if (!id) id = ids[0]
 
     const dbTemplate: delTemplate = await global.db
@@ -181,7 +222,7 @@ router.get('/templates', async (req, res) => {
 
     if (dbTemplate) try {
         const template = await discord.bot.api.guilds.templates(id).get() as APITemplate
-        
+
         await global.db.collection("templates").updateOne(
             { _id: id },
             {
@@ -215,7 +256,52 @@ router.get('/templates', async (req, res) => {
 
         await templateCache.updateTemplate(id);
     } catch (e) {
-        (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync template **${dbTemplate.name}** \`(${id})\`: ${e}\n<${settings.website.url}/templates/${id}>`)
+        const template = await discord.bot.api.guilds.templates(id).get() as APITemplate
+        // may as well reduce the load on web mods - AJ
+        await global.db
+            .collection("templates")
+            .deleteOne({ _id: id });
+
+        await global.db.collection("audit").insertOne({
+            type: "REMOVE_TEMPLATE",
+            executor: "AutoSync",
+            target: id,
+            date: Date.now(),
+            reason: "Failed to autosync template, assuming it has been deleted from discord",
+            reasonType: 0 // since this is the only option i guess? - AJ
+        });
+
+        await templateCache.deleteTemplate(id);
+
+        const embed = new MessageEmbed();
+        embed.setColor(0x2f3136);
+        embed.setTitle("Reason");
+        embed.setDescription(req.body.reason);
+
+        (await discord.channels.logs).send({
+            content: `${settings.emoji.delete} **AutoSync System** removed template **${functions.escapeFormatting(
+                template.name
+            )}** \`(${id})\``,
+            embeds: [embed]
+        });
+
+        const owner = await discord.getMember(template.creator_id);
+        if (owner)
+            owner
+                .send(
+                    `${settings.emoji.delete
+                    } **|** Your template **${functions.escapeFormatting(
+                        template.name
+                    )}** \`(${id
+                    })\` has been removed!\n**Reason:** \`Our AutoSync system has determined this template has been deleted from discord.\``
+                )
+                .catch((e) => {
+                    console.error(e);
+                });
+
+        await discord.postWebMetric("template");
+        // keeping the below just in-case the team wants it still.
+        // (await discord.channels.alerts).send(`${settings.emoji.warn} failed to autosync template **${dbTemplate.name}** \`(${id})\`: ${e}\n<${settings.website.url}/templates/${id}>`)
     }
 
     await global.redis?.hset("autosync", "nextTemplate", getNext(ids, id))

--- a/src/Routes/bots.ts
+++ b/src/Routes/bots.ts
@@ -170,7 +170,7 @@ router.post(
                     error = true;
                     errors.push(res.__("common.error.bot.arr.clientIDIsUser"));
                 })
-                .catch(() => {});
+                .catch(() => { });
         }
 
         if (req.body.invite === "") {
@@ -292,13 +292,13 @@ router.post(
                     });
 
             if (fetchServer)
-            await fetch(`https://stonks.widgetbot.io/api/graphql`, {
-                method: 'post',
-                body: JSON.stringify({
-                    query: `{guild(id:"${req.body.widgetServer}"){id}}`
-                }),
-                headers: { 'Content-Type': 'application/json' },
-            }).then(async (fetchRes: fetchRes) => {
+                await fetch(`https://stonks.widgetbot.io/api/graphql`, {
+                    method: 'post',
+                    body: JSON.stringify({
+                        query: `{guild(id:"${req.body.widgetServer}"){id}}`
+                    }),
+                    headers: { 'Content-Type': 'application/json' },
+                }).then(async (fetchRes: fetchRes) => {
                     const data: any = await fetchRes.json();
                     if (data && !data.guild?.id) {
                         error = true;
@@ -498,7 +498,7 @@ router.post(
                                     auth: {
                                         accessToken,
                                         refreshToken,
-                                        expires: Date.now() + result.expires_in*1000
+                                        expires: Date.now() + result.expires_in * 1000
                                     }
                                 }
                             }
@@ -508,14 +508,14 @@ router.post(
                 })
             }
 
-            const receivedCommands = await (await fetch(DAPI+Routes.applicationCommands(req.body.id), {headers: {authorization: `Bearer ${req.user.db.auth.accessToken}`}})).json().catch(() => {}) as APIApplicationCommand[]
+            const receivedCommands = await (await fetch(DAPI + Routes.applicationCommands(req.body.id), { headers: { authorization: `Bearer ${req.user.db.auth.accessToken}` } })).json().catch(() => { }) as APIApplicationCommand[]
             if (Array.isArray(receivedCommands)) commands = receivedCommands;
         }
 
         let userFlags = 0
 
         if (req.body.bot) {
-            const user = await discord.bot.api.users(req.body.id).get().catch(() => {}) as APIUser
+            const user = await discord.bot.api.users(req.body.id).get().catch(() => { }) as APIUser
             if (user.public_flags) userFlags = user.public_flags
         }
 
@@ -616,15 +616,13 @@ router.post(
                     }
                 } as delBot);
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
-                    )}** \`(${
-                        req.user.id
+                    )}** \`(${req.user.id
                     })\` added bot **${functions.escapeFormatting(
                         app.name
-                    )}** \`(${req.body.id})\`\n<${settings.website.url}/bots/${
-                        req.body.id
+                    )}** \`(${req.body.id})\`\n<${settings.website.url}/bots/${req.body.id
                     }>`
                 );
 
@@ -1083,7 +1081,7 @@ router.post(
                             res.__("common.error.bot.arr.clientIDIsUser")
                         );
                     })
-                    .catch(() => {});
+                    .catch(() => { });
         }
 
         const botExists: delBot | undefined = await global.db
@@ -1133,7 +1131,7 @@ router.post(
                     res.__("common.error.listing.arr.invite.discordapp")
                 );
             } else if (req.body.invite.includes("discord.com") &&
-            (req.body.bot && !req.body.invite.includes(OAuth2Scopes.Bot) || req.body.slashCommands && !req.body.invite.includes(OAuth2Scopes.ApplicationsCommands))) {
+                (req.body.bot && !req.body.invite.includes(OAuth2Scopes.Bot) || req.body.slashCommands && !req.body.invite.includes(OAuth2Scopes.ApplicationsCommands))) {
                 error = true;
                 errors.push(
                     res.__("common.error.bot.arr.scopesNotInInvite")
@@ -1297,7 +1295,7 @@ router.post(
                     });
 
             if (fetchChannel)
-            await fetch(`https://stonks.widgetbot.io/api/graphql`, {
+                await fetch(`https://stonks.widgetbot.io/api/graphql`, {
                     method: 'post',
                     body: JSON.stringify({
                         query: `{channel(id:"${req.body.widgetChannel}"){id}}`
@@ -1447,7 +1445,7 @@ router.post(
                                     auth: {
                                         accessToken,
                                         refreshToken,
-                                        expires: Date.now() + result.expires_in*1000
+                                        expires: Date.now() + result.expires_in * 1000
                                     }
                                 }
                             }
@@ -1457,14 +1455,14 @@ router.post(
                 })
             }
 
-            const receivedCommands = await (await fetch(DAPI+Routes.applicationCommands(bot._id), {headers: {authorization: `Bearer ${req.user.db.auth.accessToken}`}})).json().catch(() => {}) as APIApplicationCommand[]
+            const receivedCommands = await (await fetch(DAPI + Routes.applicationCommands(bot._id), { headers: { authorization: `Bearer ${req.user.db.auth.accessToken}` } })).json().catch(() => { }) as APIApplicationCommand[]
             if (Array.isArray(receivedCommands)) commands = receivedCommands;
         }
 
         let userFlags = 0
 
         if (req.body.bot) {
-            const user = await discord.bot.api.users(bot._id).get().catch(() => {}) as APIUser
+            const user = await discord.bot.api.users(bot._id).get().catch(() => { }) as APIUser
             if (user.public_flags) userFlags = user.public_flags
         }
 
@@ -1631,17 +1629,15 @@ router.post(
                 });
                 await botCache.updateBot(req.params.id);
 
-                await discord.channels.logs.send(
-                        `${settings.emoji.edit} **${functions.escapeFormatting(
-                            req.user.db.fullUsername
-                        )}** \`(${
-                            req.user.id
-                        })\` edited bot **${functions.escapeFormatting(
-                            app.name
-                        )}** \`(${app.id})\`\n<${settings.website.url}/bots/${
-                            req.params.id
-                        }>`
-                    )
+                (await discord.channels.logs).send(
+                    `${settings.emoji.edit} **${functions.escapeFormatting(
+                        req.user.db.fullUsername
+                    )}** \`(${req.user.id
+                    })\` edited bot **${functions.escapeFormatting(
+                        app.name
+                    )}** \`(${app.id})\`\n<${settings.website.url}/bots/${req.params.id
+                    }>`
+                )
                     .catch((e) => {
                         console.error(e);
                     });
@@ -1763,16 +1759,12 @@ router.get("/:id", variables, async (req: Request, res: Response) => {
 
         if (user) {
             editorsLength !== looped
-                ? (editors += `<a class="has-text-white" href="${
-                      settings.website.url
-                  }${res.locals.linkPrefix}/users/${user._id}">${
-                      sen(user.fullUsername) || "Unknown#0000"
-                  }</a>,&nbsp;`)
-                : (editors += `<a class="has-text-white" href="${
-                      settings.website.url
-                  }${res.locals.linkPrefix}/users/${user._id}">${
-                      sen(user.fullUsername) || "Unknown#0000"
-                  }</a>`);
+                ? (editors += `<a class="has-text-white" href="${settings.website.url
+                    }${res.locals.linkPrefix}/users/${user._id}">${sen(user.fullUsername) || "Unknown#0000"
+                    }</a>,&nbsp;`)
+                : (editors += `<a class="has-text-white" href="${settings.website.url
+                    }${res.locals.linkPrefix}/users/${user._id}">${sen(user.fullUsername) || "Unknown#0000"
+                    }</a>`);
         } else {
             if (editorsLength === looped)
                 editors = editors.substring(0, editors.length - 2);
@@ -1804,7 +1796,7 @@ router.get(
     permission.auth,
     async (req, res) => {
         res.send(String(await global.redis?.hexists("bots", req.params.id)))
-})
+    })
 
 router.get(
     "/:id/src",
@@ -1942,7 +1934,7 @@ router.get(
             }
         );
 
-        await botCache.updateBot(<string> bot._id);
+        await botCache.updateBot(<string>bot._id);
 
         res.redirect(`/bots/${bot._id}`);
     }
@@ -2095,13 +2087,11 @@ router.get(
                 req: req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` deleted bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
+            )}** \`(${req.user.id
+            })\` deleted bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
             })\``
         );
 
@@ -2157,13 +2147,11 @@ router.get(
                 req: req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.archive} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` archived bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
+            )}** \`(${req.user.id
+            })\` archived bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
             })\``
         );
 
@@ -2225,13 +2213,11 @@ router.get(
                 req: req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.hide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` hid bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
+            )}** \`(${req.user.id
+            })\` hid bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
             })\``
         );
 
@@ -2292,13 +2278,11 @@ router.get(
                 req: req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.unhide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` unhid bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
+            )}** \`(${req.user.id
+            })\` unhid bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
             })\``
         );
 
@@ -2414,7 +2398,7 @@ router.post(
                         error = true
                         errors.push(res.__("common.error.bot.arr.clientIDIsUser"));
                     })
-                    .catch(() => {});
+                    .catch(() => { });
         }
 
         const botExists: delBot | undefined = await global.db
@@ -2631,13 +2615,13 @@ router.post(
                     });
 
             if (fetchChannel)
-            await fetch(`https://stonks.widgetbot.io/api/graphql`, {
-                method: 'post',
-                body: JSON.stringify({
-                    query: `{channel(id:"${req.body.widgetChannel}"){id}}`
-                }),
-                headers: { 'Content-Type': 'application/json' },
-            }).then(async (fetchRes: fetchRes) => {
+                await fetch(`https://stonks.widgetbot.io/api/graphql`, {
+                    method: 'post',
+                    body: JSON.stringify({
+                        query: `{channel(id:"${req.body.widgetChannel}"){id}}`
+                    }),
+                    headers: { 'Content-Type': 'application/json' },
+                }).then(async (fetchRes: fetchRes) => {
                     const data: any = await fetchRes.json();
                     if (!data.channel?.id) {
                         error = true;
@@ -2776,7 +2760,7 @@ router.post(
                                     auth: {
                                         accessToken,
                                         refreshToken,
-                                        expires: Date.now() + result.expires_in*1000
+                                        expires: Date.now() + result.expires_in * 1000
                                     }
                                 }
                             }
@@ -2786,14 +2770,14 @@ router.post(
                 })
             }
 
-            const receivedCommands = await (await fetch(DAPI+Routes.applicationCommands(bot._id), {headers: {authorization: `Bearer ${req.user.db.auth.accessToken}`}})).json().catch(() => {}) as APIApplicationCommand[]
+            const receivedCommands = await (await fetch(DAPI + Routes.applicationCommands(bot._id), { headers: { authorization: `Bearer ${req.user.db.auth.accessToken}` } })).json().catch(() => { }) as APIApplicationCommand[]
             if (Array.isArray(receivedCommands)) commands = receivedCommands;
         }
 
         let userFlags = 0
 
         if (req.body.bot) {
-            const user = await discord.bot.api.users(bot._id).get().catch(() => {}) as APIUser
+            const user = await discord.bot.api.users(bot._id).get().catch(() => { }) as APIUser
             if (user.public_flags) userFlags = user.public_flags
         }
 
@@ -2953,17 +2937,15 @@ router.post(
                 });
                 await botCache.updateBot(req.params.id);
 
-                await discord.channels.logs.send(
-                        `${settings.emoji.resubmit} **${functions.escapeFormatting(
-                            req.user.db.fullUsername
-                        )}** \`(${
-                            req.user.id
-                        })\` resubmitted bot **${functions.escapeFormatting(
-                            app.name
-                        )}** \`(${app.id})\`\n<${settings.website.url}/bots/${
-                            app.id
-                        }>`
-                    )
+                (await discord.channels.logs).send(
+                    `${settings.emoji.resubmit} **${functions.escapeFormatting(
+                        req.user.db.fullUsername
+                    )}** \`(${req.user.id
+                    })\` resubmitted bot **${functions.escapeFormatting(
+                        app.name
+                    )}** \`(${app.id})\`\n<${settings.website.url}/bots/${app.id
+                    }>`
+                )
                     .catch((e) => {
                         console.error(e);
                     });
@@ -3045,17 +3027,15 @@ router.get(
             }
         );
 
-        await discord.channels.logs.send(
-                `${settings.emoji.check} **${functions.escapeFormatting(
-                    req.user.db.fullUsername
-                )}** \`(${
-                    req.user.id
-                })\` approved bot **${functions.escapeFormatting(
-                    bot.name
-                )}** \`(${bot._id})\`\n<${settings.website.url}/bots/${
-                    bot._id
-                }>`
-            )
+        (await discord.channels.logs).send(
+            `${settings.emoji.check} **${functions.escapeFormatting(
+                req.user.db.fullUsername
+            )}** \`(${req.user.id
+            })\` approved bot **${functions.escapeFormatting(
+                bot.name
+            )}** \`(${bot._id})\`\n<${settings.website.url}/bots/${bot._id
+            }>`
+        )
             .catch((e) => {
                 console.error(e);
             });
@@ -3064,12 +3044,10 @@ router.get(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.check
+                    `${settings.emoji.check
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
-                    )}** \`(${bot._id})\` has been approved on the website!${
-                        !bot.scopes || bot.scopes.bot ? '\n\nYour bot will be added to our server within the next 24 hours.' : ''
+                    )}** \`(${bot._id})\` has been approved on the website!${!bot.scopes || bot.scopes.bot ? '\n\nYour bot will be added to our server within the next 24 hours.' : ''
                     }`
                 )
                 .catch((e) => {
@@ -3080,9 +3058,9 @@ router.get(
         if (mainGuildOwner)
             mainGuildOwner.roles
                 .add(settings.roles.developer, "User's bot was just approved.")
-                .catch((e) => {
+                .catch(async (e) => {
                     console.error(e);
-                    discord.channels.alerts.send(
+                    (await discord.channels.alerts).send(
                         `${settings.emoji.error} Failed giving <@${bot.owner.id}> \`${bot.owner.id}\` the role **Bot Developer** upon one of their bots being approved.`
                     );
                 });
@@ -3091,9 +3069,9 @@ router.get(
         if (mainGuildBot)
             mainGuildBot.roles
                 .add(settings.roles.bot, "Bot was approved on the website.")
-                .catch((e) => {
+                .catch(async (e) => {
                     console.error(e);
-                    discord.channels.alerts.send(
+                    (await discord.channels.alerts).send(
                         `${settings.emoji.error} Failed giving <@${bot._id}> \`${bot._id}\` the role **Bot** upon being approved on the website.`
                     );
                 });
@@ -3102,9 +3080,9 @@ router.get(
         if (botStaffServer)
             botStaffServer
                 .kick("Bot was approved on the website.")
-                .catch((e) => {
+                .catch(async (e) => {
                     console.error(e);
-                    discord.channels.alerts.send(
+                    (await discord.channels.alerts).send(
                         `${settings.emoji.error} Failed kicking <@${bot._id}> \`${bot._id}\` from the Testing Server on approval.`
                     );
                 });
@@ -3160,9 +3138,9 @@ router.get(
                     settings.roles.premiumBot,
                     "Bot was given premium on the website."
                 )
-                .catch((e) => {
+                .catch(async (e) => {
                     console.error(e);
-                    discord.channels.alerts.send(
+                    (await discord.channels.alerts).send(
                         `${settings.emoji.error} Failed giving <@${botMember.id}> \`${botMember.id}\` the role **Premium Bot** upon being given premium on the website.`
                     );
                 });
@@ -3374,14 +3352,12 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.cross} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` declined bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
-            })\``,
+            )}** \`(${req.user.id
+                })\` declined bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
+                })\``,
             embeds: [embed]
         });
 
@@ -3397,12 +3373,10 @@ router.post(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.cross
+                    `${settings.emoji.cross
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
-                    )}** \`(${bot._id})\` has been declined.\n**Reason:** \`${
-                        req.body.reason || "None specified."
+                    )}** \`(${bot._id})\` has been declined.\n**Reason:** \`${req.body.reason || "None specified."
                     }\``
                 )
                 .catch((e) => {
@@ -3533,14 +3507,13 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.unapprove} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` unapproved bot **${functions.escapeFormatting(
-                bot.name
-            )}** \`(${bot._id})\``,
+            )}** \`(${req.user.id
+                })\` unapproved bot **${functions.escapeFormatting(
+                    bot.name
+                )}** \`(${bot._id})\``,
             embeds: [embed]
         });
 
@@ -3557,12 +3530,10 @@ router.post(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.unapprove
+                    `${settings.emoji.unapprove
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
-                    )}** \`(${bot._id})\` has been unapproved!\n**Reason:** \`${
-                        req.body.reason || "None specified."
+                    )}** \`(${bot._id})\` has been unapproved!\n**Reason:** \`${req.body.reason || "None specified."
                     }\``
                 )
                 .catch((e) => {
@@ -3693,14 +3664,12 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` removed bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
-            })\``,
+            )}** \`(${req.user.id
+                })\` removed bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
+                })\``,
             embeds: [embed]
         });
 
@@ -3719,12 +3688,10 @@ router.post(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.delete
+                    `${settings.emoji.delete
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
-                    )}** \`(${bot._id})\` has been removed!\n**Reason:** \`${
-                        req.body.reason || "None specified."
+                    )}** \`(${bot._id})\` has been removed!\n**Reason:** \`${req.body.reason || "None specified."
                     }\``
                 )
                 .catch((e) => {
@@ -3844,14 +3811,12 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.hide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
-            )}** \`(${
-                req.user.id
-            })\` hid bot **${functions.escapeFormatting(bot.name)}** \`(${
-                bot._id
-            })\``,
+            )}** \`(${req.user.id
+                })\` hid bot **${functions.escapeFormatting(bot.name)}** \`(${bot._id
+                })\``,
             embeds: [embed]
         });
 
@@ -3859,12 +3824,10 @@ router.post(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.hide
+                    `${settings.emoji.hide
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
-                    )}** \`(${bot._id})\` has been hidden!\n**Reason:** \`${
-                        req.body.reason || "None specified."
+                    )}** \`(${bot._id})\` has been hidden!\n**Reason:** \`${req.body.reason || "None specified."
                     }\``
                 )
                 .catch((e) => {
@@ -3922,17 +3885,15 @@ router.get(
             }
         );
 
-        await discord.channels.logs.send(
-                `${settings.emoji.unhide} **${functions.escapeFormatting(
-                    req.user.db.fullUsername
-                )}** \`(${
-                    req.user.id
-                })\` unhid bot **${functions.escapeFormatting(
-                    bot.name
-                )}** \`(${bot._id})\`\n<${settings.website.url}/bots/${
-                    bot._id
-                }>`
-            )
+        (await discord.channels.logs).send(
+            `${settings.emoji.unhide} **${functions.escapeFormatting(
+                req.user.db.fullUsername
+            )}** \`(${req.user.id
+            })\` unhid bot **${functions.escapeFormatting(
+                bot.name
+            )}** \`(${bot._id})\`\n<${settings.website.url}/bots/${bot._id
+            }>`
+        )
             .catch((e) => {
                 console.error(e);
             });
@@ -3941,8 +3902,7 @@ router.get(
         if (owner)
             owner
                 .send(
-                    `${
-                        settings.emoji.check
+                    `${settings.emoji.check
                     } **|** Your bot **${functions.escapeFormatting(
                         bot.name
                     )}** \`(${bot._id})\` has been unhidden on the website!`
@@ -4002,7 +3962,7 @@ router.get(
                                     auth: {
                                         accessToken,
                                         refreshToken,
-                                        expires: Date.now() + result.expires_in*1000
+                                        expires: Date.now() + result.expires_in * 1000
                                     }
                                 }
                             }
@@ -4012,14 +3972,14 @@ router.get(
                 })
             }
 
-            const receivedCommands = await (await fetch(DAPI+Routes.applicationCommands(bot._id), {headers: {authorization: `Bearer ${req.user.db.auth.accessToken}`}})).json().catch(() => {}) as APIApplicationCommand[]
+            const receivedCommands = await (await fetch(DAPI + Routes.applicationCommands(bot._id), { headers: { authorization: `Bearer ${req.user.db.auth.accessToken}` } })).json().catch(() => { }) as APIApplicationCommand[]
             if (Array.isArray(receivedCommands)) commands = receivedCommands;
         }
 
         let userFlags = 0
 
         if (bot.scopes?.bot) {
-            const user = await discord.bot.api.users(bot._id).get().catch(() => {}) as APIUser
+            const user = await discord.bot.api.users(bot._id).get().catch(() => { }) as APIUser
             if (user.public_flags) userFlags = user.public_flags
         }
 

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -126,18 +126,18 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
     let icon = "fa-robot has-text-default";
     let title = res.__("common.bots.discord")
     let subtitle = res.__("common.bots.subtitle");
-    let bots: delBot[];
+    let bots = (await botCache.getAllBots()) as delBot[]; // avoid redundant extra code // queries
     let pageParam = '?page='
-
+    let pages = await global.redis?.hget("bots", "all")
     if (req.query.tag) {
         pageParam = `?tag=${req.query.tag}&page=`
-
         switch ((req.query.tag as string).toLowerCase()) {
             case "slashcommands":
+                pages = await global.redis?.get("bots.slashcommands")
                 icon = "fa-slash fa-flip-horizontal has-text-blurple";
                 title = res.__("common.bots.title.applicationCommands")
                 subtitle = res.__("common.bots.subtitle.filter.applicationCommands", { a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>" })
-                bots = (await botCache.getAllBots()).slice(
+                bots = bots.slice(
                     15 * Number(req.query.page) - 15,
                     15 * Number(req.query.page)
                 ).filter(
@@ -146,10 +146,11 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "fun":
+                pages = await global.redis?.get("bots.fun")
                 icon = "fa-grin-squint-tears has-text-link";
                 title = res.__("common.bots.title.fun")
                 subtitle = res.__("common.bots.subtitle.filter.fun");
-                bots = (await botCache.getAllBots()).slice(
+                bots = bots.slice(
                     15 * Number(req.query.page) - 15,
                     15 * Number(req.query.page)
                 ).filter(
@@ -158,10 +159,11 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "social":
+                pages = await global.redis?.get("bots.social")
                 icon = "fa-comments-alt has-text-info";
                 title = res.__("common.bots.title.social")
                 subtitle = res.__("common.bots.subtitle.filter.social");
-                bots = (await botCache.getAllBots()).slice(
+                bots = bots.slice(
                     15 * Number(req.query.page) - 15,
                     15 * Number(req.query.page)
                 ).filter(
@@ -170,10 +172,11 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "economy":
+                pages = await global.redis?.get("bots.economy")
                 icon = "fa-comments-dollar has-text-success";
                 title = res.__("common.bots.title.economy")
                 subtitle = res.__("common.bots.subtitle.filter.economy");
-                bots = (await botCache.getAllBots()).slice(
+                bots = bots.slice(
                     15 * Number(req.query.page) - 15,
                     15 * Number(req.query.page)
                 ).filter(
@@ -182,10 +185,11 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "utility":
+                pages = await global.redis?.get("bots.utility")
                 icon = "fa-cogs has-text-orange";
                 title = res.__("common.bots.title.utility")
                 subtitle = res.__("common.bots.subtitle.filter.utility");
-                bots = (await botCache.getAllBots()).slice(
+                bots = bots.slice(
                     15 * Number(req.query.page) - 15,
                     15 * Number(req.query.page)
                 ).filter(
@@ -194,6 +198,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "moderation":
+                pages = await global.redis?.get("bots.moderation")
                 icon = "fa-gavel has-text-danger";
                 title = res.__("common.bots.title.moderation")
                 subtitle = res.__("common.bots.subtitle.filter.moderation");
@@ -206,6 +211,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "multipurpose":
+                pages = await global.redis?.get("bots.multipurpose")
                 icon = "fa-ball-pile has-text-magenta";
                 title = res.__("common.bots.title.multipurpose")
                 subtitle = res.__("common.bots.subtitle.filter.multipurpose");
@@ -218,6 +224,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 );
                 break;
             case "music":
+                pages = await global.redis?.get("bots.music")
                 icon = "fa-comment-music has-text-pink";
                 title = res.__("common.bots.title.music")
                 subtitle = res.__("common.bots.subtitle.filter.music");
@@ -255,7 +262,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
         pageParam,
         botsPgArr: bots,
         page: req.query.page,
-        pages: Math.ceil(bots.length / 15)
+        pages: Math.ceil(Number(pages) / 15)
     });
 });
 
@@ -264,7 +271,10 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
 
     if (!req.query.page) req.query.page = "1";
 
-    const servers = (await serverCache.getAllServers()).filter(
+    const servers = (await serverCache.getAllServers()).slice(
+        15 * Number(req.query.page) - 15,
+        15 * Number(req.query.page)
+    ).filter(
         ({ _id, status }) => status && !status.reviewRequired
     );
 
@@ -273,10 +283,7 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
         subtitle: res.__("common.servers.subtitle"),
         req,
         servers,
-        serversPgArr: servers.slice(
-            15 * Number(req.query.page) - 15,
-            15 * Number(req.query.page)
-        ),
+        serversPgArr: servers,
         page: req.query.page,
         pages: Math.ceil(servers.length / 15)
     });

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -126,129 +126,92 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
     let icon = "fa-robot has-text-default";
     let title = res.__("common.bots.discord")
     let subtitle = res.__("common.bots.subtitle");
-    let bots = (await botCache.getAllBots()) as delBot[]; // avoid redundant extra code // queries
+    let bots: delBot[];
     let pageParam = '?page='
-    let pages = await global.redis?.hget("bots", "all")
+    
     if (req.query.tag) {
         pageParam = `?tag=${req.query.tag}&page=`
+
         switch ((req.query.tag as string).toLowerCase()) {
             case "slashcommands":
-                pages = await global.redis?.get("bots.slashcommands")
                 icon = "fa-slash fa-flip-horizontal has-text-blurple";
                 title = res.__("common.bots.title.applicationCommands")
-                subtitle = res.__("common.bots.subtitle.filter.applicationCommands", { a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>" })
-                bots = bots.slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                subtitle = res.__("common.bots.subtitle.filter.applicationCommands", {a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>"})
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, scopes }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && scopes?.slashCommands
                 );
                 break;
             case "fun":
-                pages = await global.redis?.get("bots.fun")
                 icon = "fa-grin-squint-tears has-text-link";
                 title = res.__("common.bots.title.fun")
                 subtitle = res.__("common.bots.subtitle.filter.fun");
-                bots = bots.slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Fun")
                 );
                 break;
             case "social":
-                pages = await global.redis?.get("bots.social")
                 icon = "fa-comments-alt has-text-info";
                 title = res.__("common.bots.title.social")
                 subtitle = res.__("common.bots.subtitle.filter.social");
-                bots = bots.slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Social")
                 );
                 break;
             case "economy":
-                pages = await global.redis?.get("bots.economy")
                 icon = "fa-comments-dollar has-text-success";
                 title = res.__("common.bots.title.economy")
                 subtitle = res.__("common.bots.subtitle.filter.economy");
-                bots = bots.slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Economy")
                 );
                 break;
             case "utility":
-                pages = await global.redis?.get("bots.utility")
                 icon = "fa-cogs has-text-orange";
                 title = res.__("common.bots.title.utility")
                 subtitle = res.__("common.bots.subtitle.filter.utility");
-                bots = bots.slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Utility")
                 );
                 break;
             case "moderation":
-                pages = await global.redis?.get("bots.moderation")
                 icon = "fa-gavel has-text-danger";
                 title = res.__("common.bots.title.moderation")
                 subtitle = res.__("common.bots.subtitle.filter.moderation");
-                bots = (await botCache.getAllBots()).slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Moderation")
                 );
                 break;
             case "multipurpose":
-                pages = await global.redis?.get("bots.multipurpose")
                 icon = "fa-ball-pile has-text-magenta";
                 title = res.__("common.bots.title.multipurpose")
                 subtitle = res.__("common.bots.subtitle.filter.multipurpose");
-                bots = (await botCache.getAllBots()).slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Multipurpose")
                 );
                 break;
             case "music":
-                pages = await global.redis?.get("bots.music")
                 icon = "fa-comment-music has-text-pink";
                 title = res.__("common.bots.title.music")
                 subtitle = res.__("common.bots.subtitle.filter.music");
-                bots = (await botCache.getAllBots()).slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+                bots = (await botCache.getAllBots()).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Music")
                 );
                 break;
-            default:
-                bots = (await botCache.getAllBots()).slice(
-                    15 * Number(req.query.page) - 15,
-                    15 * Number(req.query.page)
-                ).filter(
+            default: 
+                bots = (await botCache.getAllBots()).filter(
                     ({ status }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden
                 );
         }
-    } else bots = (await botCache.getAllBots()).slice(
-        15 * Number(req.query.page) - 15,
-        15 * Number(req.query.page)
-    ).filter(
+    } else bots = (await botCache.getAllBots()).filter(
         ({ status }) =>
             status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden
     );
@@ -260,9 +223,12 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
         bots,
         icon: icon,
         pageParam,
-        botsPgArr: bots,
+        botsPgArr: bots.slice(
+            15 * Number(req.query.page) - 15,
+            15 * Number(req.query.page)
+        ),
         page: req.query.page,
-        pages: Math.ceil(Number(pages) / 15)
+        pages: Math.ceil(bots.length / 15)
     });
 });
 

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -27,14 +27,14 @@ import * as serverCache from "../Util/Services/serverCaching.js";
 import * as templateCache from "../Util/Services/templateCaching.js";
 import * as discord from "../Util/Services/discord.js";
 import { variables } from "../Util/Function/variables.js";
-import type { GuildMember } from "discord.js";
+import type { Guild, GuildMember, GuildMemberManager } from "discord.js";
 
 const router = express.Router();
 
 const nickSorter = (a, b) =>
     (a.nick || a.user.username).localeCompare(b.nick || b.user.username);
 function sortAll() {
-    let members = discord.guilds.main.members;
+    let members = (async () => { return (await discord.guilds.main).members }).call(this) as GuildMemberManager;
     if (!members) throw new Error("Fetching members failed!");
     const staff: GuildMember[] = [],
         donators: GuildMember[] = [],
@@ -53,10 +53,10 @@ function sortAll() {
             member.rank = admin
                 ? "admin"
                 : assistant
-                ? "assistant"
-                : mod
-                ? "mod"
-                : null;
+                    ? "assistant"
+                    : mod
+                        ? "mod"
+                        : null;
             const user = discord.bot.users.cache.get(member.id);
             member.avatar = user.avatar;
             member.username = user.username;
@@ -128,7 +128,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
     let subtitle = res.__("common.bots.subtitle");
     let bots: delBot[];
     let pageParam = '?page='
-    
+
     if (req.query.tag) {
         pageParam = `?tag=${req.query.tag}&page=`
 
@@ -136,7 +136,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
             case "slashcommands":
                 icon = "fa-slash fa-flip-horizontal has-text-blurple";
                 title = res.__("common.bots.title.applicationCommands")
-                subtitle = res.__("common.bots.subtitle.filter.applicationCommands", {a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>"})
+                subtitle = res.__("common.bots.subtitle.filter.applicationCommands", { a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>" })
                 bots = (await botCache.getAllBots()).filter(
                     ({ status, scopes }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && scopes?.slashCommands
@@ -205,7 +205,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Music")
                 );
                 break;
-            default: 
+            default:
                 bots = (await botCache.getAllBots()).filter(
                     ({ status }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -137,7 +137,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-slash fa-flip-horizontal has-text-blurple";
                 title = res.__("common.bots.title.applicationCommands")
                 subtitle = res.__("common.bots.subtitle.filter.applicationCommands", { a: '<a class="has-text-info" href="https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ" target="_blank" rel="noopener">', a2: '<a class="has-text-info" href="https://discord.com/developers/docs/interactions/application-commands#user-commands" target="_blank" rel="noopener">', ea: "</a>" })
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, scopes }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && scopes?.slashCommands
                 );
@@ -146,7 +149,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-grin-squint-tears has-text-link";
                 title = res.__("common.bots.title.fun")
                 subtitle = res.__("common.bots.subtitle.filter.fun");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Fun")
                 );
@@ -155,7 +161,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-comments-alt has-text-info";
                 title = res.__("common.bots.title.social")
                 subtitle = res.__("common.bots.subtitle.filter.social");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Social")
                 );
@@ -164,7 +173,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-comments-dollar has-text-success";
                 title = res.__("common.bots.title.economy")
                 subtitle = res.__("common.bots.subtitle.filter.economy");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Economy")
                 );
@@ -173,7 +185,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-cogs has-text-orange";
                 title = res.__("common.bots.title.utility")
                 subtitle = res.__("common.bots.subtitle.filter.utility");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Utility")
                 );
@@ -182,7 +197,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-gavel has-text-danger";
                 title = res.__("common.bots.title.moderation")
                 subtitle = res.__("common.bots.subtitle.filter.moderation");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Moderation")
                 );
@@ -191,7 +209,10 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-ball-pile has-text-magenta";
                 title = res.__("common.bots.title.multipurpose")
                 subtitle = res.__("common.bots.subtitle.filter.multipurpose");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Multipurpose")
                 );
@@ -200,18 +221,27 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
                 icon = "fa-comment-music has-text-pink";
                 title = res.__("common.bots.title.music")
                 subtitle = res.__("common.bots.subtitle.filter.music");
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status, tags }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden && tags.includes("Music")
                 );
                 break;
             default:
-                bots = (await botCache.getAllBots()).filter(
+                bots = (await botCache.getAllBots()).slice(
+                    15 * Number(req.query.page) - 15,
+                    15 * Number(req.query.page)
+                ).filter(
                     ({ status }) =>
                         status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden
                 );
         }
-    } else bots = (await botCache.getAllBots()).filter(
+    } else bots = (await botCache.getAllBots()).slice(
+        15 * Number(req.query.page) - 15,
+        15 * Number(req.query.page)
+    ).filter(
         ({ status }) =>
             status.approved && !status.siteBot && !status.archived && !status.hidden && !status.modHidden
     );
@@ -223,10 +253,7 @@ router.get("/bots", variables, async (req: Request, res: Response) => {
         bots,
         icon: icon,
         pageParam,
-        botsPgArr: bots.slice(
-            15 * Number(req.query.page) - 15,
-            15 * Number(req.query.page)
-        ),
+        botsPgArr: bots,
         page: req.query.page,
         pages: Math.ceil(bots.length / 15)
     });

--- a/src/Routes/servers.ts
+++ b/src/Routes/servers.ts
@@ -45,6 +45,7 @@ import { ParamsDictionary } from "express-serve-static-core";
 import { ParsedQs } from "qs";
 const md = new mdi
 const router = express.Router();
+let reviewRequired = false; // Needs to be outside of the functions or it cannot be referenced outside of x function - AJ
 
 function serverType(bodyType: string): number {
     let type: serverReasons = parseInt(bodyType);
@@ -81,7 +82,6 @@ function tagHandler(req: express.Request<ParamsDictionary, any, any, ParsedQs, R
     if (req.body.contCreat === true) tags.push("Content Creation");
     if (req.body.nsfw === true) tags.push("NSFW");
 
-    let reviewRequired = false;
     if (req.body.lgbt === true) {
         tags.push("LGBT");
         if (server) {
@@ -293,7 +293,7 @@ router.post(
                     }
                 } as delServer);
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -702,7 +702,7 @@ router.post(
                     }
                 );
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -935,7 +935,7 @@ router.post(
         embed.setURL(`${settings.website.url}/servers/${server._id}`);
         embed.setFooter("It will still be shown as a normal server, it was declined from being listed as an LGBT community.");
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.cross} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1029,7 +1029,7 @@ router.get(
 
         await serverCache.updateServer(req.params.id);
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
                 `${settings.emoji.check} **${functions.escapeFormatting(
                     req.user.db.fullUsername
                 )}** \`(${
@@ -1091,7 +1091,7 @@ router.get(
                 req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1202,7 +1202,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Routes/staff.ts
+++ b/src/Routes/staff.ts
@@ -140,7 +140,7 @@ router.get(
             .toArray();
 
         for (const bot of bots) {
-            discord.guilds.main.members.cache.has(bot._id)
+            (await discord.guilds.main).members.cache.has(bot._id)
                 ? (bot.inServer = true)
                 : (bot.inServer = false);
         }

--- a/src/Routes/templates.ts
+++ b/src/Routes/templates.ts
@@ -196,7 +196,7 @@ router.post(
                     }
                 } as delTemplate);
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -563,7 +563,7 @@ router.post(
                     }
                 );
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -701,7 +701,7 @@ router.get(
                 req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -815,7 +815,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Util/Services/banned.ts
+++ b/src/Util/Services/banned.ts
@@ -28,7 +28,7 @@ export async function check(user: string): Promise<boolean> {
 export async function updateBanlist() {
     await global.redis?.del("bans");
     const bans = await (await guilds.main).bans.fetch().catch(e => console.error(e)) as Collection<string, GuildBan>;
-    await global.redis?.hmset(
+    if(bans.size > 0) await global.redis?.hmset(
         "bans",
         ...bans.map((ban) => [ban.user.id, true])
     );

--- a/src/Util/Services/banned.ts
+++ b/src/Util/Services/banned.ts
@@ -17,6 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Collection, GuildBan } from "discord.js";
 import { guilds } from "./discord.js";
 
 export async function check(user: string): Promise<boolean> {
@@ -26,7 +27,7 @@ export async function check(user: string): Promise<boolean> {
 
 export async function updateBanlist() {
     await global.redis?.del("bans");
-    const bans = await guilds.main.bans.fetch().catch(e => console.error(e));
+    const bans = await (await guilds.main).bans.fetch().catch(e => console.error(e)) as Collection<string, GuildBan>;
     await global.redis?.hmset(
         "bans",
         ...bans.map((ban) => [ban.user.id, true])

--- a/src/Util/Services/botCaching.ts
+++ b/src/Util/Services/botCaching.ts
@@ -58,14 +58,6 @@ export async function uploadBots() {
         prefix,
         ...botsDB.map((bot: delBot) => [bot._id, JSON.stringify(bot)])
     );
-    // since we are loading all those in, let's go ahead and mark those long pagination tag queries in the cache too
-    let available = botsDB.filter((bot) => bot.status.approved && !bot.status.siteBot && !bot.status.archived && !bot.status.hidden && !bot.status.modHidden) as delBot[];
-    const tags = ["fun", "social", "economy", "utility", "moderation", "multipurpose", "music"]
-    await global.redis?.set("bots.all", available.length)
-    await global.redis?.set("bots.slashcommands", available.filter(({ scopes }) => scopes?.slashCommands).length)
-    for (const tag of tags) {
-        await global.redis?.set(`bots.${tag}`, available.filter(({ tags }) => tags.includes(`${tag.charAt(0).toUpperCase()+tag.substring(1).toLowerCase()}`)).length)
-    }
 
 }
 

--- a/src/Util/Services/botCaching.ts
+++ b/src/Util/Services/botCaching.ts
@@ -18,7 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 const prefix = "bots";
-
 export async function getBot(id: string): Promise<delBot> {
     const bot = await global.redis?.hget(prefix, id);
     if (!bot) return;
@@ -59,6 +58,15 @@ export async function uploadBots() {
         prefix,
         ...botsDB.map((bot: delBot) => [bot._id, JSON.stringify(bot)])
     );
+    // since we are loading all those in, let's go ahead and mark those long pagination tag queries in the cache too
+    let available = botsDB.filter((bot) => bot.status.approved && !bot.status.siteBot && !bot.status.archived && !bot.status.hidden && !bot.status.modHidden) as delBot[];
+    const tags = ["fun", "social", "economy", "utility", "moderation", "multipurpose", "music"]
+    await global.redis?.set("bots.all", available.length)
+    await global.redis?.set("bots.slashcommands", available.filter(({ scopes }) => scopes?.slashCommands).length)
+    for (const tag of tags) {
+        await global.redis?.set(`bots.${tag}`, available.filter(({ tags }) => tags.includes(`${tag.charAt(0).toUpperCase()+tag.substring(1).toLowerCase()}`)).length)
+    }
+
 }
 
 export async function deleteBot(id: string) {

--- a/src/Util/Services/discord.ts
+++ b/src/Util/Services/discord.ts
@@ -29,7 +29,7 @@ import { hostname } from "os";
 const prefix = "statuses";
 // If someone is to self-host or contribute, setting datadog metrics is a lot,
 // if they have nothing set in the secret section of settings.json, let's ignore metrics - AJ
-if (!settings.secrets.datadog) metrics.init({ host: "", prefix: "", apiKey: settings.secrets.datadog });
+if (settings.secrets.datadog) metrics.init({ host: "", prefix: "", apiKey: settings.secrets.datadog });
 
 // @ts-expect-error
 class Client extends Discord.Client {

--- a/src/Util/Services/discord.ts
+++ b/src/Util/Services/discord.ts
@@ -31,6 +31,13 @@ const prefix = "statuses";
 // if they have nothing set in the secret section of settings.json, let's ignore metrics - AJ
 if (settings.secrets.datadog) metrics.init({ host: "", prefix: "", apiKey: settings.secrets.datadog });
 
+// Let's not query the database of users, and bots, and then make changes to it every 5 seconds, that would be a good thing not to do
+setInterval(async () => {
+    postWebMetric("user");
+    postWebMetric("bot_unapproved");
+    await postTodaysGrowth();
+}, 8.568e+7); // 23.8h, to account for eventual time drift if the site is online for a while (which is the goal lol) - AJ
+
 // @ts-expect-error
 class Client extends Discord.Client {
     readonly api: {
@@ -278,9 +285,3 @@ export async function postTodaysGrowth() {
         );
     } else return;
 }
-
-setInterval(async () => {
-    postWebMetric("user");
-    postWebMetric("bot_unapproved");
-    await postTodaysGrowth();
-}, 5000);

--- a/src/Util/Services/discord.ts
+++ b/src/Util/Services/discord.ts
@@ -160,7 +160,6 @@ export async function uploadStatuses() {
 export async function postMetric() {
     const guild = guilds.main;
     if (guild && settings.secrets.datadog) metrics.gauge("del.server.memberCount", guild.memberCount);
-    else return true; // My only guess is that this is holding it up somehow if datadog isn't enabled
 }
 
 export async function postWebMetric(type: string) {

--- a/src/Util/Services/discord.ts
+++ b/src/Util/Services/discord.ts
@@ -160,6 +160,7 @@ export async function uploadStatuses() {
 export async function postMetric() {
     const guild = guilds.main;
     if (guild && settings.secrets.datadog) metrics.gauge("del.server.memberCount", guild.memberCount);
+    else return true; // My only guess is that this is holding it up somehow if datadog isn't enabled
 }
 
 export async function postWebMetric(type: string) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,7 +46,7 @@ import { sitemapIndex, sitemapGenerator } from "./Util/Middleware/sitemap.js";
 
 import i18n from "i18n";
 import { MongoClient } from "mongodb";
-import { RedisOptions } from "ioredis";
+import Redis from "ioredis"
 import { hostname } from "os";
 
 import settings from "../settings.json" assert { type: "json" };
@@ -147,7 +147,7 @@ new Promise<void>((resolve, reject) => {
                 .then(() => true)
                 .catch(() => false);
         }
-        let redisConfig: RedisOptions;
+        let redisConfig: Redis.RedisOptions;
 
         if (settings.secrets.redis.sentinels.length > 0) {
             redisConfig = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -280,7 +280,7 @@ new Promise<void>((resolve, reject) => {
         app.use(
             cookieSession({
                 name: "delSession",
-                secret: settings.secrets.cookie,
+                keys: [settings.secrets.cookie],
                 maxAge: 1000 * 60 * 60 * 24 * 7
             })
         );

--- a/src/app.ts
+++ b/src/app.ts
@@ -226,10 +226,6 @@ new Promise<void>((resolve, reject) => {
 
         await discord.bot.login(settings.secrets.discord.token);
 
-        await new Promise<void>((resolve) => {
-            discord.bot.once("ready", () => resolve());
-        });
-
         setTimeout(async () => {
             await featuredCache.updateFeaturedBots();
             await discord.postMetric();


### PR DESCRIPTION
All changes were tested *except* for autosync auto deletion for templates and servers. I'll need someone to verify that works, it should though. 

Changes:
- Edited a number of queries that were being run for counts, to only attempt to fetch the estimated mongodb count, vs actually fetching the items, putting them into an array, and checking the length. 
- Changed the interval in which "daily" metrics postings occurred, to actually be a day (23.8h to be exact) and not be posting every **5 seconds**. This was... causing a lot of problems
- Changed how the site launches, it was possible for it to become "stuck" if it happened to execute quickly- it would end up waiting for the bot to emit ready. but it never got to the point where the bot could emit ready, as it held the process up.
- If the datadog variable is an empty string, or null in the settings.json file, don't attempt to log metrics
- Changed a few files to no longer call **all** databases, even when there is a switch operator to control what metrics need to be updated. Ie: Don't waste time and resources querying things that aren't being used currently
- For automatic banlist updating, and this will only impact servers with no bans, or development testing- if there are no bans to be found, don't attempt to set a null value in redis
- For express, the cookie-session module wants an array of strings now, even though it isn't mentioned in the docs, I tried it a few times. I just tossed the settings string into an array to make it happy.

TLDR; The site shouldn't hang and die anymore, at least it didn't in my testing. I also am assuming any memory leak that did exist, has been fixed with these changes (from what I can see anyway, and the stats, this is correct).