### PR TITLE
Fix search hanging and servers page

### DIFF
--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -236,8 +236,9 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
     res.locals.premidPageInfo = res.__("premid.servers");
 
     if (!req.query.page) req.query.page = "1";
-
-    const servers = (await serverCache.getAllServers()).slice(
+    // Can't calculate total pages with sliced value - AJ
+    const allServers = await serverCache.getAllServers()
+    const servers = [...allServers].slice(
         15 * Number(req.query.page) - 15,
         15 * Number(req.query.page)
     ).filter(
@@ -251,7 +252,7 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
         servers,
         serversPgArr: servers,
         page: req.query.page,
-        pages: Math.ceil(servers.length / 15)
+        pages: Math.ceil(allServers.length / 15)
     });
 });
 

--- a/src/Routes/search.ts
+++ b/src/Routes/search.ts
@@ -97,7 +97,7 @@ router.post("/", variables, async (req: Request, res: Response) => {
                         _id === query ||
                         fullUsername.toLowerCase().indexOf(query) >= 0
                 )
-                .map((user) => {
+                .map(async (user) => {
                     return ejs.renderFile(renderPath + "/cards/userCard.ejs", {
                         req,
                         linkPrefix: res.locals.linkPrefix,
@@ -117,7 +117,7 @@ router.post("/", variables, async (req: Request, res: Response) => {
                     ({ status }) =>
                         !status.archived && status.approved && !status.siteBot && !status.hidden && !status.modHidden
                 )
-                .map((bot) => {
+                .map(async (bot) => {
                     return ejs.renderFile(renderPath + "/cards/botCard.ejs", {
                         req,
                         linkPrefix: res.locals.linkPrefix,
@@ -136,7 +136,7 @@ router.post("/", variables, async (req: Request, res: Response) => {
                     ({ _id, name }) =>
                         _id === query || name.toLowerCase().indexOf(query) >= 0
                 )
-                .map((server) => {
+                .map(async (server) => {
                     return ejs.renderFile(
                         renderPath + "/cards/serverCard.ejs",
                         {
@@ -156,7 +156,7 @@ router.post("/", variables, async (req: Request, res: Response) => {
                     ({ _id, name }) =>
                         _id === query || name.toLowerCase().indexOf(query) >= 0
                 )
-                .map((template) => {
+                .map(async (template) => {
                     return ejs.renderFile(
                         renderPath + "/cards/templateCard.ejs",
                         {

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,10 @@ import passport from "passport";
 import logger from "morgan";
 
 import * as libCache from "./Util/Services/libCaching.js";
+import { uploadBots } from "./Util/Services/botCaching.js";
+import { uploadServers } from "./Util/Services/serverCaching.js";
+import { uploadTemplates } from "./Util/Services/templateCaching.js";
+/*Not uploading users, as that isn't a publicly searchable function, and they are re-set/cached on login/auth, if need be - AJ*/
 import * as announcementCache from "./Util/Services/announcementCaching.js";
 import * as featuredCache from "./Util/Services/featuring.js";
 import * as ddosMode from "./Util/Services/ddosMode.js";
@@ -172,7 +176,7 @@ new Promise<void>((resolve, reject) => {
         const s = new Redis(redisConfig);
 
         /*There is no point in flushing the DEL redis database, it's persistent as is, and will lead to problems. - Ice*/
-
+        /*Ref #1 - While ice is totally right, we also aren't caching things at all unless it's being added, which means god forbid it get cleared, or flushed somehow, it doesn't work, which explains some issues - AJ*/
         console.log("Attempting to acquire caching lock...");
         const lock = await global.redis.get("cache_lock");
         if (lock && lock != hostname()) { // We have a lock, but it is not held for us.
@@ -211,6 +215,10 @@ new Promise<void>((resolve, reject) => {
             console.log("Also acquired the discord lock!");
             await global.redis.setex("cache_lock", 300, hostname());
             console.time("Redis");
+            /*Relates to Ref #1 above, we weren't caching servers, bots, or templates on startup, and these were never called. Meaning some queries are failing (from what debugging results in anyway) - AJ*/
+            await uploadBots()
+            await uploadServers() // may perhaps be a bit intensive, but with a set of 15000 randomly generated entries, it didn't take too terribly long ~1ms, especially if results already exist and reply with 0 (or string for hmset)
+            await uploadTemplates()
             await libCache.cacheLibs();
             await announcementCache.updateCache();
             await featuredCache.updateFeaturedServers();

--- a/views/templates/search.ejs
+++ b/views/templates/search.ejs
@@ -94,7 +94,7 @@
 
         const input = document.querySelector("input.input.is-rounded.is-dark#searchInput");
 
-        if (input.value.match(/gay(\s+)?(men\s+)?.*/i)) return window.location.href = "/users/302604426781261824";
+        // if (input.value.match(/gay(\s+)?(men\s+)?.*/i)) return window.location.href = "/users/302604426781261824"; - This causes simple terms like "gay" to result in a redirect, which is, not intended is my guess - AJ
         if (input.value.toLowerCase() === "developers developers developers developers") return document.body.innerHTML = `<iframe width="100%" height="100%" src="https://www.youtube.com/embed/KMU0tzLwhbE?controls=0&autoplay=1" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
         
         const c = document.querySelector("input[type='checkbox']#users");
@@ -131,7 +131,6 @@
         })
         .then(data => {
             let content = "";
-
             if (data.data.pages.length !== 0) {
                 for (const card of data.data.pages[0]) {
                     content = content + card;


### PR DESCRIPTION
So, this took a bit actually. Since the redis database is created with non-expiring keys, the cache should be intact, without the need for the methods uploadBots, etc. Once I realized that wasn't the problem, I tested manually adding the page=# to the query on the production site- this resulted in pages of results, that didn't seem to be shown. That was a different issue, that is also resolved in this PR. The random bottleneck/hanging on queries such as "anime" or "furry" occurred when I had created empty/fake datasets to have to search through. This makes sense, since some queries work fine, some not. The issue with some terms is the size of the results. It seems that the bottleneck was coming from .map, and expressjs trying to render everything, all results across every page, synchronously. it seems simply changing the inner function of the map where ejs is called to be asynchronous does the trick? 